### PR TITLE
ci: Add `Build and publish package` workflow

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 package-lock.json
 node_modules
 dist/*
+resources/*

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Build and push package
+on:
+  pull_request:
+    branches: 
+      - main
+  push:
+    branches:
+      - main
+
+
+jobs:
+  build:
+      uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@v0.37.0'
+      with:
+        node: '[
+                {"version": "18", "tests": false, "lint": true},
+              ]'
+
+  publish:
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
+    needs: build
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.37.0'
+    with:
+      package_name: node-red-dashboard-2-ui-flowviewer
+      publish_package: true
+    secrets:
+      npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Build and push package
+name: Build and publish package
 on:
   pull_request:
     branches: 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@flowfuse/node-red-dashboard-2-ui-flowviewer",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@flowfuse/node-red-dashboard-2-ui-flowviewer",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "Apache-2.0",
             "dependencies": {
                 "@flowfuse/flow-renderer": "^0.4.1",
@@ -20,6 +20,7 @@
                 "eslint-plugin-import": "^2.29.0",
                 "eslint-plugin-n": "^16.3.1",
                 "eslint-plugin-vue": "^9.18.1",
+                "sort-package-json": "^2.11.0",
                 "vite": "^5.0.13",
                 "vite-plugin-css-injected-by-js": "^3.3.0"
             },
@@ -1242,6 +1243,27 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/detect-indent": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-7.0.1.tgz",
+            "integrity": "sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
+        "node_modules/detect-newline": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-4.0.1.tgz",
+            "integrity": "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "dev": true,
@@ -1775,6 +1797,20 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fdir": {
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.2.tgz",
+            "integrity": "sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==",
+            "dev": true,
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "dev": true,
@@ -1893,6 +1929,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-stdin": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+            "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/get-symbol-description": {
             "version": "1.0.0",
             "dev": true,
@@ -1917,6 +1965,15 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/git-hooks-list": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-3.1.0.tgz",
+            "integrity": "sha512-LF8VeHeR7v+wAbXqfgRlTSX/1BJR9Q1vEMR8JAz1cEg6GX07+zyj3sAdDvYjj/xnlIfVuGgj4qBei1K3hKH+PA==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
             }
         },
         "node_modules/glob": {
@@ -2264,6 +2321,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-regex": {
@@ -2686,6 +2755,18 @@
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
             "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
         },
+        "node_modules/picomatch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.4.47",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -2985,6 +3066,43 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/sort-object-keys": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+            "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+            "dev": true
+        },
+        "node_modules/sort-package-json": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.11.0.tgz",
+            "integrity": "sha512-pBs3n/wcsbnMSiO5EYV4AVnZVtyQslfZ/0v6VbrRRVApqyNf0Uqo4MOXJsBmIplGY1hYZ4bq5qjO9xTgY+K8xw==",
+            "dev": true,
+            "dependencies": {
+                "detect-indent": "^7.0.1",
+                "detect-newline": "^4.0.0",
+                "get-stdin": "^9.0.0",
+                "git-hooks-list": "^3.0.0",
+                "is-plain-obj": "^4.1.0",
+                "semver": "^7.6.0",
+                "sort-object-keys": "^1.1.3",
+                "tinyglobby": "^0.2.9"
+            },
+            "bin": {
+                "sort-package-json": "cli.js"
+            }
+        },
+        "node_modules/sort-package-json/node_modules/semver": {
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3091,6 +3209,19 @@
             "version": "0.2.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.10",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.10.tgz",
+            "integrity": "sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==",
+            "dev": true,
+            "dependencies": {
+                "fdir": "^6.4.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/tsconfig-paths": {
             "version": "3.14.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "eslint-plugin-import": "^2.29.0",
         "eslint-plugin-n": "^16.3.1",
         "eslint-plugin-vue": "^9.18.1",
+        "sort-package-json": "^2.11.0",
         "vite": "^5.0.13",
         "vite-plugin-css-injected-by-js": "^3.3.0"
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
         "lint:js": "eslint --ext .js,.vue,.cjs,.mjs .",
         "lint:js:fix": "yarn lint:js --fix",
         "lint:package": "sort-package-json --check 'package.json'",
-        "lint:package:fix": "sort-package-json 'package.json'"
+        "lint:package:fix": "sort-package-json 'package.json'",
+        "test": "echo \"Error: no tests specified\" && exit 0"
     },
     "dependencies": {
         "@flowfuse/flow-renderer": "^0.4.1",

--- a/ui/main.js
+++ b/ui/main.js
@@ -5,6 +5,6 @@
  */
 import { createApp } from 'vue'
 
-import UIIframe from './components/UIIframe.vue'
+import UIFlowViewer from './components/UIFlowViewer.vue'
 
-createApp(UIIframe).mount('#app')
+createApp(UIFlowViewer).mount('#app')


### PR DESCRIPTION
## Description

This pull request introduces `Build and publish package` workflow responsible for publishing `node-red-dashboard-2-ui-flowviewer` package to the npmjs.com registry.

## Related Issue(s)

Closes https://github.com/FlowFuse/node-red-dashboard-2-ui-flowviewer/issues/5

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

